### PR TITLE
feat: FAQ 질문/답변 조회 기능 구현

### DIFF
--- a/app/api/endpoints/faq.py
+++ b/app/api/endpoints/faq.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from app.api.deps import get_db, get_current_user
+from app.models.user import User
+from app.schemas.faq import FAQCategorySchema, FAQQuestionListSchema, FAQQuestionDetailSchema
+from app.crud import faq_crud
+
+router = APIRouter()
+
+# (1) 카테고리 목록 조회 - 비로그인 허용
+@router.get("/categories", response_model=List[FAQCategorySchema])
+def get_categories(db: Session = Depends(get_db)):
+    return faq_crud.get_all_categories(db)
+
+
+# (2) 질문 목록 조회 - 비로그인 허용 (답변 없이)
+@router.get("/questions", response_model=List[FAQQuestionListSchema])
+def get_questions(
+    category_id: Optional[int] = Query(None, description="카테고리 ID"),
+    db: Session = Depends(get_db)
+):
+    return faq_crud.get_questions(db, category_id)
+
+
+# (3) 질문 상세 조회 - 로그인한 사용자만 answer 포함
+@router.get("/questions/{question_id}", response_model=FAQQuestionDetailSchema)
+def get_question_detail(
+    question_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    question = faq_crud.get_question_by_id(db, question_id)
+    if not question:
+        raise HTTPException(status_code=404, detail="질문을 찾을 수 없습니다.")
+    return question

--- a/app/api/routers.py
+++ b/app/api/routers.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.endpoints import user, auth, chat # 여기서 guide도 나중에 추가 가능
+from app.api.endpoints import user, auth, chat, faq # 여기서 guide도 나중에 추가 가능
 
 router = APIRouter()
 
@@ -7,3 +7,4 @@ router = APIRouter()
 router.include_router(user.router, prefix="/auth", tags=["User"])
 router.include_router(auth.router, prefix="/auth", tags=["Auth"])
 router.include_router(chat.router, prefix="/chat", tags=["Chat"])
+router.include_router(faq.router, prefix="/faq", tags=["FAQ"])

--- a/app/crud/faq_crud.py
+++ b/app/crud/faq_crud.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from app.models.faq import FAQCategory, FAQQuestion
+
+def get_all_categories(db: Session) -> List[FAQCategory]:
+    return db.query(FAQCategory).all()
+
+def get_questions(db: Session, category_id: Optional[int] = None) -> List[FAQQuestion]:
+    query = db.query(FAQQuestion)
+    if category_id:
+        query = query.filter(FAQQuestion.category_id == category_id)
+    return query.all()
+
+def get_question_by_id(db: Session, question_id: int) -> Optional[FAQQuestion]:
+    return db.query(FAQQuestion).filter(FAQQuestion.question_id == question_id).first()

--- a/app/models/faq.py
+++ b/app/models/faq.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, Text, String, ForeignKey, DateTime, func
+from app.db.base import Base
+
+class FAQCategory(Base):
+    __tablename__ = "faq_categories"
+
+    category_id = Column(Integer, primary_key=True, index=True)
+    title = Column(Text, nullable=False)
+
+class FAQQuestion(Base):
+    __tablename__ = "faq_questions"
+
+    question_id = Column(Integer, primary_key=True, index=True)
+    category_id = Column(Integer, ForeignKey("faq_categories.category_id"), nullable=False)
+    question = Column(Text, nullable=False)
+    answer = Column(Text, nullable=False)
+    reference_title = Column(String(255))
+    reference_url = Column(Text)
+    created_at = Column(DateTime, server_default=func.now())  # 자동 타임스탬프

--- a/app/schemas/faq.py
+++ b/app/schemas/faq.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class FAQCategorySchema(BaseModel):
+    category_id: int
+    title: str
+
+    class Config:
+        from_attributes = True
+
+class FAQQuestionListSchema(BaseModel):
+    question_id: int
+    category_id: int
+    question: str
+
+    class Config:
+        from_attributes = True
+
+class FAQQuestionDetailSchema(FAQQuestionListSchema):
+    answer: str
+    reference_title: Optional[str]
+    reference_url: Optional[str]


### PR DESCRIPTION
###  주요 기능 구현 요약
- FAQ 시스템 초기 구현
- 비로그인 사용자는 카테고리 및 질문 목록 조회 가능
- 로그인한 사용자만 질문의 상세 답변 열람 가능

---

### 추가된 파일

| 파일 경로 | 설명 |
|-----------|------|
| `app/models/faq.py` | FAQ 카테고리 및 질문 테이블에 대한 SQLAlchemy 모델 정의 |
| `app/schemas/faq.py` | 질문 목록/상세 및 카테고리 응답용 Pydantic 스키마 정의 |
| `app/crud/faq_crud.py` | FAQ 관련 DB 접근 함수 정의 (카테고리/질문 조회 등) |
| `app/api/endpoints/faq.py` | FAQ 관련 API 엔드포인트 정의 (비로그인/로그인 분기 포함) |

---

### 테스트 내역

- [x] `GET /faq/categories` → 비로그인 상태에서 카테고리 목록 조회 성공
- [x] `GET /faq/questions?category_id=1` → 비로그인 상태에서 질문 목록 조회 성공
- [x] `GET /faq/questions/{question_id}` → 로그인 사용자만 답변 확인 가능 (비로그인 시 401 에러)

---

### 인증 처리

- `get_current_user` 디펜던시를 통해 `question_id` 상세 조회 시 로그인 사용자만 접근 가능하도록 구현
- 비로그인 사용자는 질문과 카테고리 목록은 조회 가능하되, 답변은 제한됨