### PR TITLE
fix: stop.sh 수정으로 CodeDeploy ScriptTimedOut 오류 해결

### DIFF
--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-# 애플리케이션 중지 명령어
 echo "Stopping the FastAPI application using systemd..."
-sudo systemctl stop carebridges.service  # carebridges.service 중지
+sudo systemctl stop carebridges.service
+
+# 5초 후 상태 확인
+sleep 5
+
+if systemctl is-active --quiet carebridges.service; then
+    echo "Service did not stop cleanly. Forcing shutdown..."
+    pid=$(pgrep gunicorn)
+    if [ -n "$pid" ]; then
+        sudo kill -9 $pid
+        echo "Gunicorn process forcefully killed."
+    fi
+fi
+
 echo "FastAPI application stopped."


### PR DESCRIPTION
###  수정 내용
- `stop.sh`가 30초 내에 종료되지 않아 발생하던 `ScriptTimedOut` 오류 해결
- gunicorn 프로세스가 종료되지 않을 경우를 대비해 `kill -9` 로직 추가

###  변경 사항
- `stop.sh`: 프로세스 종료 실패 시 강제 종료 로직 추가
- `carebridges.service`: (Git 미관리 시스템 파일)에 ExecStop, TimeoutStopSec, KillMode 설정을 수동으로 추가하여 종료 안정성 향상

###  기대 효과
- CodeDeploy 배포 과정 중 ApplicationStop 단계에서의 실패 방지
- 서비스 종료 안정성 및 배포 신뢰도 향상
