### PR TITLE
feat: 회원가입에 phone 필수 도입

### DIFF
--- a/app/api/endpoints/user.py
+++ b/app/api/endpoints/user.py
@@ -23,7 +23,7 @@ def register_user(user_create: SimpleUserCreate, db: Session = Depends(get_db)):
             },
         )
 
-    # 여기까지 오면 Pydantic이 name/비밀번호 검증을 이미 끝낸 상태
+    # 여기까지 오면 Pydantic이 name/비밀번호/전화번호 검증을 이미 끝낸 상태
     return create_simple_user(db, user_create)
 
 
@@ -32,4 +32,5 @@ def read_current_user(current_user: User = Depends(get_current_user)):
     return {
         "email": current_user.email,
         "name": current_user.name,
+        "phone": current_user.phone,
     }

--- a/app/crud/user_crud.py
+++ b/app/crud/user_crud.py
@@ -12,6 +12,7 @@ def create_simple_user(db: Session, user_create: SimpleUserCreate) -> User:
         email=user_create.email,
         name=user_create.name,
         password=hashed_pw,
+        phone=user_create.phone,
     )
     db.add(user)
     db.commit()

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -7,7 +7,7 @@ class User(Base):
 
     worker_id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(50), nullable=False)
-    phone = Column(String(20), nullable=True)  
+    phone = Column(String(20), nullable=False)  
     email = Column(String(100), unique=True, nullable=False)
     password = Column(String(255), nullable=False)
     organization = Column(String(100), nullable=True)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,35 +1,49 @@
+import re
 from pydantic import BaseModel, EmailStr, field_validator, FieldValidationInfo
 from typing import Optional
 from datetime import datetime
+
+# 전화번호 정규식 (하이픈 필수)
+PHONE_RE = re.compile(r"^01[016789]-\d{3,4}-\d{4}$")
 
 class SimpleUserCreate(BaseModel):
     email: EmailStr
     name: str
     password1: str
     password2: str
+    phone: str
 
     # 공통 빈값 방지
-    @field_validator("email", "name", "password1", "password2", mode="after")
+    @field_validator("email", "name", "password1", "password2", "phone", mode="after")
     @classmethod
     def not_empty(cls, v: str) -> str:
         if not v or not v.strip():
             raise ValueError("빈 값은 허용되지 않습니다.")
         return v
 
-    # 비밀번호 일치 검증: password2에 에러 매핑
+    # 비밀번호 일치 검증
     @field_validator("password2", mode="after")
     @classmethod
     def passwords_match(cls, v: str, info: FieldValidationInfo) -> str:
         pw1 = info.data.get("password1")
         if pw1 is not None and v != pw1:
-            # 이 예외는 password2 필드의 검증 에러로 연결됩니다 (422)
             raise ValueError("비밀번호가 일치하지 않습니다.")
         return v
+
+    # 전화번호 형식 검증 
+    @field_validator("phone", mode="after")
+    @classmethod
+    def validate_phone(cls, v: str) -> str:
+        if not PHONE_RE.fullmatch(v):
+            raise ValueError("전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678")
+        return v
+
 
 class UserOut(BaseModel):
     worker_id: int
     email: str
     name: str
+    phone: str
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,6 +36,18 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "certifi"
+version = "2025.8.3"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
+    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 description = "Composable command line interface toolkit"
@@ -262,6 +274,53 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -747,4 +806,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "e711d8a8c530747d04019983435a772da9160f3e34f97d435d0f4c339500b05a"
+content-hash = "d2965519ced60c5ef04ab88e5d8bbfa1eeb7bf04d6fe50469b6d5491585ab87d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "email-validator (>=2.2.0,<3.0.0)",
     "python-multipart (>=0.0.20,<0.0.21)",
     "gunicorn (>=23.0.0,<24.0.0)",
-    "pymysql (>=1.1.1,<2.0.0)"
+    "pymysql (>=1.1.1,<2.0.0)",
+    "httpx (>=0.28.1,<0.29.0)"
 
 ]
 


### PR DESCRIPTION
- schemas/user.py
  - SimpleUserCreate에 phone 필드 추가 (필수)
  - 전화번호 정규식 검증 추가: ^01[016789]-\d{3,4}-\d{4}$ (하이픈 필수)
  - UserOut에 phone 포함

- crud/user_crud.py
  - create_simple_user에서 phone 저장

- api/user.py
  - /register 응답 스키마(UserOut) 반영
  - /me 응답에 phone 추가

- models/user.py
  - phone 컬럼 nullable=False로 변경 (NOT NULL 전제)
  - 마이그레이션 시 기존 NULL 데이터 백필 필요