### PR TITLE
feat: 아이디 찾기 API 추가 및 phone 컬럼 UNIQUE적용

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -10,6 +10,8 @@ from app.schemas.token import Token
 from app.models.user import User
 from datetime import timedelta
 from app.core.config import settings
+from app.schemas.auth import FindEmailRequest, FindEmailResponse 
+from app.crud.user_crud import get_user_by_name_phone 
 
 router = APIRouter()
 
@@ -110,3 +112,13 @@ def logout(request: Request):
         path="/auth/refresh"
     )
     return response
+
+@router.post("/find-email", response_model=FindEmailResponse, status_code=status.HTTP_200_OK)
+def find_email(payload: FindEmailRequest, db: Session = Depends(get_db)):
+    user = get_user_by_name_phone(db, payload.name, payload.phone)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": "일치하는 회원을 찾을 수 없습니다."}
+        )
+    return FindEmailResponse(email=user.email)  # 전체 이메일 반환

--- a/app/api/endpoints/user.py
+++ b/app/api/endpoints/user.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from app.schemas.user import SimpleUserCreate, UserOut
-from app.crud.user_crud import get_user_by_email, create_simple_user
+from app.crud.user_crud import get_user_by_email, get_user_by_phone, create_simple_user
 from app.db.session import get_db
 from app.models.user import User
 from app.api.deps import get_current_user
@@ -20,6 +20,15 @@ def register_user(user_create: SimpleUserCreate, db: Session = Depends(get_db)):
                 "errors": [
                     {"field": "email", "message": "이미 등록된 이메일입니다.", "code": "duplicate"}
                 ],
+            },
+        )
+    # 전화번호 중복 검사
+    if get_user_by_phone(db, user_create.phone):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "이미 등록된 전화번호입니다.",
+                "errors": [{"field": "phone", "message": "이미 등록된 전화번호입니다.", "code": "duplicate"}],
             },
         )
 

--- a/app/crud/user_crud.py
+++ b/app/crud/user_crud.py
@@ -6,6 +6,13 @@ from app.utils.security import get_password_hash
 def get_user_by_email(db: Session, email: str):
     return db.query(User).filter(User.email == email).first()
 
+def get_user_by_phone(db: Session, phone: str):
+    return db.query(User).filter(User.phone == phone).first()
+
+def get_user_by_name_phone(db: Session, name: str, phone: str):
+    return db.query(User).filter(User.name == name, User.phone == phone).first()
+
+
 def create_simple_user(db: Session, user_create: SimpleUserCreate) -> User:
     hashed_pw = get_password_hash(user_create.password1)
     user = User(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -7,7 +7,7 @@ class User(Base):
 
     worker_id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(50), nullable=False)
-    phone = Column(String(20), nullable=False)  
+    phone = Column(String(20), nullable=False, unique=True)  
     email = Column(String(100), unique=True, nullable=False)
     password = Column(String(255), nullable=False)
     organization = Column(String(100), nullable=True)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,27 @@
+# app/schemas/auth.py
+import re
+from pydantic import BaseModel, EmailStr, field_validator
+
+# 프론트 정책: 하이픈 필수 "010-1234-5678"
+PHONE_RE = re.compile(r"^01[016789]-\d{3,4}-\d{4}$")
+
+class FindEmailRequest(BaseModel):
+    name: str
+    phone: str
+
+    @field_validator("name", "phone", mode="after")
+    @classmethod
+    def not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("빈 값은 허용되지 않습니다.")
+        return v
+
+    @field_validator("phone", mode="after")
+    @classmethod
+    def validate_phone(cls, v: str) -> str:
+        if not PHONE_RE.fullmatch(v):
+            raise ValueError("전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678")
+        return v
+
+class FindEmailResponse(BaseModel):
+    email: EmailStr  # 전체 이메일 반환


### PR DESCRIPTION
### 작업 내용
- User 모델의 phone 컬럼에 UNIQUE 제약 추가 (중복 전화번호 방지)
- 회원가입 시 phone 중복 검사 로직 추가 (409 Conflict 응답)
- 이름 + 전화번호로 아이디(이메일) 찾는 API 구현
- schemas/auth.py 신규 추가: FindEmailRequest, FindEmailResponse
- user_crud.py에 get_user_by_name_phone() 함수 추가

### 테스트
- Postman에서 회원가입 → 아이디 찾기 정상 동작 확인
- name + phone 조합이 정확히 일치해야 이메일 반환됨
- 존재하지 않는 경우 404 응답 확인 완료
