### PR TITLE
feat: 비밀번호 재설정 기능 추가

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -1,90 +1,115 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Body ,Request
+from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordRequestForm
+from datetime import timedelta
+import logging
+
 from app.db.session import get_db
-from app.crud.user_crud import get_user_by_email
+from app.crud.user_crud import (
+    get_user_by_email,
+    get_user_by_name_phone,
+    create_password_reset_token,
+    verify_and_consume_reset_token,
+    update_user_password,
+)
 from app.utils.security import verify_password
 from app.utils.jwt import create_access_token, create_refresh_token, verify_refresh_token
 from app.schemas.token import Token
-from app.models.user import User
-from datetime import timedelta
+from app.schemas.auth import FindEmailRequest, FindEmailResponse
+from app.schemas.password_reset import (
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
+    ResetPasswordRequest,
+    ResetPasswordResponse,
+)
 from app.core.config import settings
-from app.schemas.auth import FindEmailRequest, FindEmailResponse 
-from app.crud.user_crud import get_user_by_name_phone 
+from app.models.user import User
+from app.utils.mailer import send_email_html
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# ----------------------------------------
 # 로그인: 액세스 토큰은 응답 본문, 리프레시 토큰은 HttpOnly 쿠키
+# ----------------------------------------
 @router.post("/login", response_model=Token)
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     user: User = get_user_by_email(db, form_data.username)
     if not user:
-        raise HTTPException(status_code=400, detail="이메일이 올바르지 않습니다.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="이메일이 올바르지 않습니다.")
 
     if not verify_password(form_data.password, user.password):
-        raise HTTPException(status_code=400, detail="비밀번호가 올바르지 않습니다.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="비밀번호가 올바르지 않습니다.")
 
     access_token = create_access_token(
         data={"sub": str(user.worker_id)},
-        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
     refresh_token = create_refresh_token(
         data={"sub": str(user.worker_id)},
-        expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+        expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
     )
 
     # refresh_token은 쿠키에 저장
-    response = JSONResponse(content={
-        "access_token": access_token,
-        "token_type": "bearer"
-    })
+    response = JSONResponse(
+        content={
+            "access_token": access_token,
+            "token_type": "bearer",
+        }
+    )
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
-        secure= True,  # HTTPS 환경에서만 전송 (운영 시 True 권장)
-        samesite="strict",  # CSRF 방지
+        secure=True,                # 운영 환경에서 HTTPS 권장
+        samesite="strict",          # CSRF 방지
         max_age=60 * 60 * 24 * settings.REFRESH_TOKEN_EXPIRE_DAYS,
-        path="/auth/refresh"
+        path="/auth/refresh",
     )
     return response
 
 
+# ----------------------------------------
+# 액세스 토큰 재발급(리프레시 토큰 검증)
+# ----------------------------------------
 @router.post("/refresh", response_model=Token)
 def refresh_token_endpoint(
     request: Request,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     refresh_token = request.cookies.get("refresh_token")
     if not refresh_token:
-        raise HTTPException(status_code=401, detail="Refresh Token이 없습니다.")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh Token이 없습니다.")
 
     payload = verify_refresh_token(refresh_token)
     user_id = payload.get("sub")
 
     user = db.query(User).filter(User.worker_id == int(user_id)).first()
     if not user:
-        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="사용자를 찾을 수 없습니다.")
 
     access_token = create_access_token(
         data={"sub": str(user.worker_id)},
-        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
 
-    #  새 리프레시 토큰도 쿠키로 갱신
+    # 새 리프레시 토큰도 쿠키로 갱신
     new_refresh_token = create_refresh_token(
         data={"sub": str(user.worker_id)},
-        expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+        expires_delta=timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
     )
 
-    response = JSONResponse(content={
-        "access_token": access_token,
-        "token_type": "bearer"
-    })
+    response = JSONResponse(
+        content={
+            "access_token": access_token,
+            "token_type": "bearer",
+        }
+    )
     response.set_cookie(
         key="refresh_token",
         value=new_refresh_token,
@@ -92,33 +117,90 @@ def refresh_token_endpoint(
         secure=True,
         samesite="strict",
         max_age=60 * 60 * 24 * settings.REFRESH_TOKEN_EXPIRE_DAYS,
-        path="/auth/refresh"
+        path="/auth/refresh",
     )
     return response
 
+
+# ----------------------------------------
+# 로그아웃: 리프레시 토큰 쿠키 삭제
+# ----------------------------------------
 @router.post("/logout")
 def logout(request: Request):
     refresh_token = request.cookies.get("refresh_token")
 
     if not refresh_token:
         raise HTTPException(
-            status_code=400,
-            detail="로그인 상태가 아닙니다. (Refresh Token 없음)"
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="로그인 상태가 아닙니다. (Refresh Token 없음)",
         )
 
     response = JSONResponse(content={"message": "로그아웃 되었습니다."})
     response.delete_cookie(
         key="refresh_token",
-        path="/auth/refresh"
+        path="/auth/refresh",
     )
     return response
 
+
+# ----------------------------------------
+# 아이디(이메일) 찾기: 이름 + 전화번호로 조회(전체 이메일 반환)
+# ----------------------------------------
 @router.post("/find-email", response_model=FindEmailResponse, status_code=status.HTTP_200_OK)
 def find_email(payload: FindEmailRequest, db: Session = Depends(get_db)):
     user = get_user_by_name_phone(db, payload.name, payload.phone)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"message": "일치하는 회원을 찾을 수 없습니다."}
+            detail={"message": "일치하는 회원을 찾을 수 없습니다."},
         )
-    return FindEmailResponse(email=user.email)  # 전체 이메일 반환
+    return FindEmailResponse(email=user.email)
+
+
+# 비밀번호 재설정 1단계
+@router.post("/forgot-password", response_model=ForgotPasswordResponse, status_code=status.HTTP_200_OK)
+def forgot_password(payload: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    user = get_user_by_email(db, payload.email)
+
+    token_for_dev = None
+    if user:
+        raw_token = create_password_reset_token(db, user.worker_id, ttl_minutes=30)
+        reset_link = f"{settings.FRONTEND_BASE_URL}/reset-password?token={raw_token}"
+
+        body = f"""
+        <p>안녕하세요, 비밀번호 재설정 안내입니다.</p>
+        <p>아래 링크를 클릭하여 새 비밀번호를 설정해 주세요.</p>
+        <p><a href="{reset_link}">{reset_link}</a></p>
+        <p>해당 링크는 30분 후 만료됩니다.</p>
+        """
+
+        try:
+            send_email_html(to_email=user.email, subject=settings.MAIL_SUBJECT_RESET, body_html=body)
+            logger.info("비밀번호 재설정 메일 발송 성공: %s", user.email)
+        except Exception as e:
+            logger.exception("비밀번호 재설정 메일 발송 실패: %s", e)
+
+        if settings.DEBUG:
+            token_for_dev = raw_token
+            logger.info("[DEV] reset token for %s: %s", user.email, raw_token)
+
+    return ForgotPasswordResponse(
+        message="비밀번호 재설정 안내를(계정이 존재한다면) 전송했습니다.",
+        reset_token_for_dev=token_for_dev,
+    )
+
+
+# 비밀번호 재설정 2단계
+@router.post("/reset-password", response_model=ResetPasswordResponse, status_code=status.HTTP_200_OK)
+def reset_password(payload: ResetPasswordRequest, db: Session = Depends(get_db)):
+    user = verify_and_consume_reset_token(db, payload.token)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"message": "유효하지 않거나 만료된 토큰입니다.", "code": "TOKEN_INVALID"},
+        )
+
+    update_user_password(db, user, payload.new_password1)
+    logger.info("비밀번호 재설정 완료: user_id=%s", user.worker_id)
+
+    return ResetPasswordResponse(message="비밀번호가 변경되었습니다.")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -4,12 +4,23 @@ class Settings(BaseSettings):
     DATABASE_URL: str
     SECRET_KEY: str
     REFRESH_SECRET_KEY: str
-    REFRESH_SECRET_KEY: str
     ALGORITHM: str  
     ACCESS_TOKEN_EXPIRE_MINUTES: int  
-    REFRESH_TOKEN_EXPIRE_DAYS: int 
     AI_SERVER_URL: AnyHttpUrl = Field(default="http://127.0.0.1:8001/chat")
     REFRESH_TOKEN_EXPIRE_DAYS: int 
+
+    FRONTEND_BASE_URL: str = "https://your-frontend.example.com"  # 리셋 링크 생성용
+
+    # 메일 설정 
+    SMTP_HOST: str = "smtp.example.com"
+    SMTP_PORT: int = 587
+    SMTP_USERNAME: str = "user"
+    SMTP_PASSWORD: str = "pass"
+    SMTP_USE_TLS: bool = True
+    MAIL_FROM: str = "no-reply@example.com"
+    MAIL_SUBJECT_RESET: str = "[Carebridges] 비밀번호 재설정 안내"
+    
+    DEBUG: bool = False
 
     class Config:
         env_file = ".env"

--- a/app/crud/user_crud.py
+++ b/app/crud/user_crud.py
@@ -1,5 +1,9 @@
 from sqlalchemy.orm import Session
+from datetime import datetime, timedelta         
+import hashlib, secrets  
+
 from app.models.user import User
+from app.models.password_reset_token import PasswordResetToken
 from app.schemas.user import SimpleUserCreate
 from app.utils.security import get_password_hash
 
@@ -25,3 +29,50 @@ def create_simple_user(db: Session, user_create: SimpleUserCreate) -> User:
     db.commit()
     db.refresh(user)
     return user
+# ===== 비밀번호 재설정 관련 =====
+
+# 토큰 생성 (원문 토큰은 이메일로만 전달, DB에는 해시만 저장) 
+def create_password_reset_token(db: Session, user_id: int, ttl_minutes: int = 30) -> str:
+    raw_token = secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+    expires_at = datetime.utcnow() + timedelta(minutes=ttl_minutes)
+
+    prt = PasswordResetToken(
+        user_id=user_id,
+        token_hash=token_hash,
+        expires_at=expires_at,
+    )
+    db.add(prt)
+    db.commit()
+    return raw_token  # 이메일 링크에 이 원문 토큰을 사용
+
+
+# 토큰 검증 + 1회성 소모  # [ADDED]
+def verify_and_consume_reset_token(db: Session, raw_token: str) -> User | None:
+    token_hash = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+    prt = (
+        db.query(PasswordResetToken)
+        .filter(
+            PasswordResetToken.token_hash == token_hash,
+            PasswordResetToken.used == False,
+        )
+        .first()
+    )
+    if not prt:
+        return None
+    if prt.expires_at < datetime.utcnow():
+        return None
+
+    prt.used = True
+    db.add(prt)
+    db.commit()
+
+    return db.query(User).filter(User.worker_id == prt.user_id).first()
+
+
+# 비밀번호 변경  # [ADDED]
+def update_user_password(db: Session, user: User, new_password: str) -> None:
+    user.password = get_password_hash(new_password)
+    db.add(user)
+    db.commit()
+    # 필요하면 db.refresh(user) 추가 가능

--- a/app/models/password_reset_token.py
+++ b/app/models/password_reset_token.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey, func
+from sqlalchemy.orm import relationship
+from app.db.base import Base
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("social_workers.worker_id", ondelete="CASCADE"), nullable=False)
+    token_hash = Column(String(128), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    used = Column(Boolean, nullable=False, server_default="0")
+    created_at = Column(DateTime, server_default=func.now())
+
+    user = relationship("User", backref="password_reset_tokens")

--- a/app/schemas/password_reset.py
+++ b/app/schemas/password_reset.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel, EmailStr, field_validator, FieldValidationInfo
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+class ForgotPasswordResponse(BaseModel):
+    message: str  # 운영에서는 토큰/개발정보 없음
+    reset_token_for_dev: str | None = None  #  운영에선 항상 null
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password1: str
+    new_password2: str
+
+    @field_validator("new_password1", "new_password2", mode="after")
+    @classmethod
+    def not_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("빈 값은 허용되지 않습니다.")
+        return v
+
+    @field_validator("new_password2", mode="after")
+    @classmethod
+    def pw_match(cls, v: str, info: FieldValidationInfo) -> str:
+        if v != info.data.get("new_password1"):
+            raise ValueError("비밀번호가 일치하지 않습니다.")
+        return v
+
+class ResetPasswordResponse(BaseModel):
+    message: str
+

--- a/app/utils/mailer.py
+++ b/app/utils/mailer.py
@@ -1,0 +1,17 @@
+import smtplib, ssl
+from email.mime.text import MIMEText
+from app.core.config import settings
+
+def send_email_html(to_email: str, subject: str, body_html: str):
+    msg = MIMEText(body_html, "html", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = settings.MAIL_FROM
+    msg["To"] = to_email
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as server:
+        if settings.SMTP_USE_TLS:
+            server.starttls(context=context)
+        if settings.SMTP_USERNAME:
+            server.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
+        server.sendmail(settings.MAIL_FROM, [to_email], msg.as_string())


### PR DESCRIPTION
## 비밀번호 재설정 기능 추가

### 주요 변경 사항
- **DB**
  - `password_reset_tokens` 테이블 추가 (토큰 해시/만료시간/1회성 소모)
- **Backend API**
  - `POST /auth/forgot-password`: 이메일로 비밀번호 재설정 링크 전송
  - `POST /auth/reset-password`: 토큰 검증 후 새 비밀번호 저장
- **메일 전송**
  - Gmail SMTP(App Password) 기반 HTML 메일 발송
  - DEBUG 모드일 때는 `reset_token` 응답에 포함하여 프론트 없이 테스트 가능
- **보안**
  - 계정 존재 여부 노출 방지를 위해 항상 동일 응답 메시지 반환
  - 비밀번호는 반드시 해시 저장(`bcrypt`)

### 테스트 시나리오 (Postman)
1. 회원 이메일로 `POST /auth/forgot-password` 요청
2. DEBUG 모드일 경우 응답의 `reset_token_for_dev` 확인
3. `POST /auth/reset-password` 요청에 토큰 + 새 비밀번호 전달
4. 로그인 API에서 새 비밀번호로 로그인 성공 확인

### 추가 고려사항
- 운영 환경에서는 반드시 **DEBUG=false** 로 설정
- MAIL_FROM 도메인은 실제 서비스용 도메인으로 변경 필요
- 프론트엔드 페이지(`/reset-password`) 연결 예정
